### PR TITLE
build: Update version vue-template-compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wallaby-vue-compiler",
   "version": "1.0.3",
   "dependencies": {
-    "vue-template-compiler": "^2.5.16"
+    "vue-template-compiler": "^2.6.6"
   },
   "main": "index.js"
 }


### PR DESCRIPTION
# What
- Update minor version `vue-template-compiler`

# Why
Vue.js was updated minor version https://medium.com/the-vue-point/vue-2-6-released-66aa6c8e785e
I'm using `"vue": "^2.6.6",`, `"vue-template-compiler": "^2.6.6",`
But, wallaby display this error.
So, I think `wallaby-vue-compiler` needs update `vue-template-compiler`
```
[Error] ​​Error: ​​
[Error] ​​​​
[Error] ​​Vue packages version mismatch:​​
[Error] ​​​​
[Error] ​​- vue@2.6.6​​
[Error] ​​- vue-template-compiler@2.5.17​​
[Error] ​​​​
[Error] ​​This may cause things to work incorrectly. Make sure to use the same version for both.​​
[Error] ​​If you are using vue-loader@>=10.0, simply update vue-template-compiler.​​
[Error] ​​If you are using vue-loader@<10.0 or vueify, re-installing vue-loader/vueify should bump vue-template-compiler to the latest.​​
```